### PR TITLE
chore: rename package to ultrachat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- chore: rename package to ultrachat

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "rest-express",
+  "name": "ultrachat",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rest-express",
+      "name": "ultrachat",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rest-express",
+  "name": "ultrachat",
   "version": "1.0.0",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- rename package to `ultrachat`
- update lockfile and changelog

## Testing
- `npm install` *(fails: npm: command not found)*
- `npm run lint` *(fails: npm: command not found)*
- `npm test` *(fails: npm: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689af270e6e883259d9018530a389896